### PR TITLE
Updated the vijava dependency once again to 5.5-beta, which this time is...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
       <dependency>
           <groupId>com.vmware</groupId>
           <artifactId>vijava</artifactId>
-          <version>5.1</version>
+          <version>5.5-beta</version>
       </dependency>
       <dependency>
           <groupId>dom4j</groupId>


### PR DESCRIPTION
... deployed to our artifactory, and is taken from http://sourceforge.net/projects/vijava/files/vijava/VI%20Java%20API%205.5%20Beta/
