### PR TITLE
Changed getDeviceIdOnAttachRequirement to REQUIRED

### DIFF
--- a/src/main/java/org/dasein/cloud/vsphere/compute/HardDiskCapabilities.java
+++ b/src/main/java/org/dasein/cloud/vsphere/compute/HardDiskCapabilities.java
@@ -115,7 +115,7 @@ public class HardDiskCapabilities extends AbstractCapabilities<PrivateCloud> imp
 
     @Override
     public @Nonnull Requirement getDeviceIdOnAttachRequirement() throws InternalException, CloudException {
-        return Requirement.NONE; // TODO: find out
+        return Requirement.REQUIRED;
     }
 
     @Override


### PR DESCRIPTION
@drewlyall HardDisk.attach fails [here](https://github.com/greese/dasein-cloud-vsphere/blob/master/src/main/java/org/dasein/cloud/vsphere/compute/HardDisk.java#L140) when passed null for deviceId
